### PR TITLE
ConnectionExceptions thrown from Bugzilla.connectTo()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,5 +34,15 @@
 			<artifactId>guava</artifactId>
 			<version>14.0.1</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.xmlrpc</groupId>
+			<artifactId>xmlrpc-client</artifactId>
+			<version>3.1.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>14.0.1</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/com/j2bugzilla/api/Bugzilla.java
+++ b/src/main/java/com/j2bugzilla/api/Bugzilla.java
@@ -3,6 +3,7 @@ package com.j2bugzilla.api;
 import java.net.URI;
 import java.util.ServiceLoader;
 import java.util.Set;
+import com.j2bugzilla.api.ConnectionException;
 
 /**
  * The {@code Bugzilla} class is the entry point into the API. This class adheres to the SPI contract.
@@ -11,7 +12,7 @@ import java.util.Set;
  * 
  * @author Tom
  */
-public abstract class Bugzilla {
+public abstract class Bugzilla{
 
 	/**
 	 * Loads and returns a new instance of {@link Bugzilla} to provide access to the various
@@ -34,13 +35,13 @@ public abstract class Bugzilla {
 	 * Connects to the given host.
 	 * @param host A {@code String} which can be parsed as a URL, pointing to the Bugzilla base.
 	 */
-	public abstract void connectTo(String host);
+	public abstract void connectTo(String host) throws ConnectionException;
 	
 	/**
 	 * Connects to the given host.
 	 * @param host A {@link URI} which points to the Bugzilla base.
 	 */
-	public abstract void connectTo(URI host);
+	public abstract void connectTo(URI host) throws ConnectionException;
 	
 	/**
 	 * Connects to the given host, providing HTTP Basic authentication credentials. Note that this does
@@ -49,7 +50,7 @@ public abstract class Bugzilla {
 	 * @param httpUser A {@code String} representing an HTTP Basic username.
 	 * @param httpPass A {@code String} representing an HTTP Basic password.
 	 */
-	public abstract void connectTo(String host, String httpUser, String httpPass);
+	public abstract void connectTo(String host, String httpUser, String httpPass) throws ConnectionException;
 	
 	/**
 	 * Connects to the given host, providing HTTP Basic authentication credentials. Note that this does
@@ -58,7 +59,7 @@ public abstract class Bugzilla {
 	 * @param httpUser A {@code String} representing an HTTP Basic username.
 	 * @param httpPass A {@code String} representing an HTTP Basic password.
 	 */
-	public abstract void connectTo(URI host, String httpUser, String httpPass);
+	public abstract void connectTo(URI host, String httpUser, String httpPass) throws ConnectionException;
 	
 	/**
 	 * Retrieves a configured instance of {@link BugRepository} to allow consumers to make queries about

--- a/src/main/java/com/j2bugzilla/api/Bugzilla.java
+++ b/src/main/java/com/j2bugzilla/api/Bugzilla.java
@@ -35,13 +35,13 @@ public abstract class Bugzilla{
 	 * Connects to the given host.
 	 * @param host A {@code String} which can be parsed as a URL, pointing to the Bugzilla base.
 	 */
-	public abstract void connectTo(String host) throws ConnectionException;
+	public abstract void connectTo(String host);
 	
 	/**
 	 * Connects to the given host.
 	 * @param host A {@link URI} which points to the Bugzilla base.
 	 */
-	public abstract void connectTo(URI host) throws ConnectionException;
+	public abstract void connectTo(URI host);
 	
 	/**
 	 * Connects to the given host, providing HTTP Basic authentication credentials. Note that this does
@@ -50,7 +50,7 @@ public abstract class Bugzilla{
 	 * @param httpUser A {@code String} representing an HTTP Basic username.
 	 * @param httpPass A {@code String} representing an HTTP Basic password.
 	 */
-	public abstract void connectTo(String host, String httpUser, String httpPass) throws ConnectionException;
+	public abstract void connectTo(String host, String httpUser, String httpPass);
 	
 	/**
 	 * Connects to the given host, providing HTTP Basic authentication credentials. Note that this does
@@ -59,7 +59,7 @@ public abstract class Bugzilla{
 	 * @param httpUser A {@code String} representing an HTTP Basic username.
 	 * @param httpPass A {@code String} representing an HTTP Basic password.
 	 */
-	public abstract void connectTo(URI host, String httpUser, String httpPass) throws ConnectionException;
+	public abstract void connectTo(URI host, String httpUser, String httpPass);
 	
 	/**
 	 * Retrieves a configured instance of {@link BugRepository} to allow consumers to make queries about

--- a/src/main/java/com/j2bugzilla/api/ConnectionException.java
+++ b/src/main/java/com/j2bugzilla/api/ConnectionException.java
@@ -26,7 +26,7 @@ package com.j2bugzilla.api;
  * @author Tom
  *
  */
-public class ConnectionException extends Exception {
+public class ConnectionException extends RuntimeException {
 
 	/**
 	 * Eclipse-generated SUID

--- a/src/main/java/com/j2bugzilla/api/ConnectionException.java
+++ b/src/main/java/com/j2bugzilla/api/ConnectionException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2011 Thomas Golden
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.j2bugzilla.api;
+
+/**
+ * <code>ConnectionException</code> is thrown any time there is an error trying to access
+ * the Bugzilla installation over the network. It may be a network-related problem such as
+ * a timeout or malformed URL, or it may be an underlying XML-RPC exception, but it
+ * generally indicates that any further Bugzilla calls will fail.
+ * 
+ * ConnectionException will always be a wrapper for a nested <code>Exception</code> which
+ * indicates the cause of the error.
+ * @author Tom
+ *
+ */
+public class ConnectionException extends Exception {
+
+	/**
+	 * Eclipse-generated SUID
+	 */
+	private static final long serialVersionUID = 2957676868743832929L;
+
+	/**
+	 * Public constructor which calls super()
+	 * @param message A custom error message describing the issue
+	 * @param cause The root cause of the exception
+	 */
+	public ConnectionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+	
+}

--- a/src/main/java/com/j2bugzilla/api/SearchBy.java
+++ b/src/main/java/com/j2bugzilla/api/SearchBy.java
@@ -81,7 +81,7 @@ public enum SearchBy {
 	
 	private final String name;
 	/**
-	 * Creates a new {@link SearchLimiter} with the
+	 * Creates a new {@link SearchBy} with the
 	 * designated name
 	 * @param name The name Bugzilla expects for this search limiter
 	 */
@@ -92,8 +92,7 @@ public enum SearchBy {
 	 * Get the name Bugzilla expects for this search limiter
 	 * @return A <code>String</code> representing the search limiter
 	 */
-	String getName() {
+	public String getName() {
 		return this.name;
 	}
-	
 }


### PR DESCRIPTION
Added the ConnectionException class from the old j2bugzilla code, and made all overloads of Bugzilla.connectTo() throw this exception, just as the BugzillaConnector did.
